### PR TITLE
Changed assignment of "throws" property 

### DIFF
--- a/assert.js
+++ b/assert.js
@@ -339,7 +339,7 @@ function _throws(shouldThrow, block, expected, message) {
 // 11. Expected to throw an error:
 // assert.throws(block, Error_opt, message_opt);
 
-assert.throws = function(block, /*optional*/error, /*optional*/message) {
+assert["throws"] = function(block, /*optional*/error, /*optional*/message) {
   _throws.apply(this, [true].concat(pSlice.call(arguments)));
 };
 


### PR DESCRIPTION
...from dot notation to square bracket notation.

In few environments, like Closure Compiler, *throws* is considered a reserved word and will cause an error.

Other implementations of assert already take this into account, e.g. https://github.com/Gozala/narwhal/blob/master/lib/assert.js#L282
