### PR TITLE
fix for enviroments that don't have node.js stuff

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "assert"
   ],
-  "version": "1.3.0",
+  "version": "1.4.0",
   "homepage": "https://github.com/defunctzombie/commonjs-assert",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "main": "./assert.js",
   "dependencies": {
+    "buffer": "^4.6.0",
     "buffer-shims": "1.0.0",
     "util": "0.10.3"
   },


### PR DESCRIPTION
apparently this library is popular with react-native which offers require but doesn't provide any of the built in node.js things