### PR TITLE
Added types.

### DIFF
--- a/assert.d.ts
+++ b/assert.d.ts
@@ -1,0 +1,57 @@
+// Type definitions for assert and power-assert
+// Project: https://github.com/Jxck/assert
+// Project: https://github.com/twada/power-assert
+// Definitions by: vvakame <https://github.com/vvakame>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// copy from assert external module in node.d.ts
+
+declare function assert(value:any, message?:string):void;
+declare namespace assert {
+    export class AssertionError implements Error {
+        name:string;
+        message:string;
+        actual:any;
+        expected:any;
+        operator:string;
+        generatedMessage:boolean;
+
+        constructor(options?:{message?: string; actual?: any; expected?: any; operator?: string; stackStartFunction?: Function});
+    }
+
+    export function fail(actual?:any, expected?:any, message?:string, operator?:string):void;
+
+    export function ok(value:any, message?:string):void;
+
+    export function equal(actual:any, expected:any, message?:string):void;
+
+    export function notEqual(actual:any, expected:any, message?:string):void;
+
+    export function deepEqual(actual:any, expected:any, message?:string):void;
+
+    export function notDeepEqual(acutal:any, expected:any, message?:string):void;
+
+    export function strictEqual(actual:any, expected:any, message?:string):void;
+
+    export function notStrictEqual(actual:any, expected:any, message?:string):void;
+
+    export var throws:{
+        (block:Function, message?:string): void;
+        (block:Function, error:Function, message?:string): void;
+        (block:Function, error:RegExp, message?:string): void;
+        (block:Function, error:(err:any) => boolean, message?:string): void;
+    };
+
+    export var doesNotThrow:{
+        (block:Function, message?:string): void;
+        (block:Function, error:Function, message?:string): void;
+        (block:Function, error:RegExp, message?:string): void;
+        (block:Function, error:(err:any) => boolean, message?:string): void;
+    };
+
+    export function ifError(value:any):void;
+}
+
+declare module "assert" {
+    export = assert;
+}

--- a/package.json
+++ b/package.json
@@ -26,5 +26,6 @@
     "test": "npm run test-node && npm run test-browser",
     "test-native": "TEST_NATIVE=true mocha --ui qunit test.js",
     "browser-local": "zuul --no-coverage --local 8000 -- test.js"
-  }
+  },
+  "types": "./assert.d.ts"
 }


### PR DESCRIPTION
I was struggling to get typescript working with this package. DefinitelyTyped has an entry for "assert", but it doesn't declare "assert" as a module. As far as I can tell, this is because people often conflict between node.d.ts and the use of assert as an external package.

Realistically, node users should use node.d.ts (and node's built-in assert module), and developers of sites and apps that require packing should use your commonjs-assert package along with its own type definition.

This would've all been avoided if this module was actually called "commonjs-assert" on npm instead of just "assert", but we're a bit beyond that.
## 

Anyway, this pull request contains the proper type definitions tightly coupled with the commonjs-assert module which means consumers of the module won't need to add a separate external dependency on @types/assert or any other such type definitions.
